### PR TITLE
use SFSafariViewController

### DIFF
--- a/AsakusaSatellite WatchKit App/Info.plist
+++ b/AsakusaSatellite WatchKit App/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/AsakusaSatellite WatchKit App/Info.plist
+++ b/AsakusaSatellite WatchKit App/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>112</string>
+	<string>114</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/AsakusaSatellite WatchKit Extension/Info.plist
+++ b/AsakusaSatellite WatchKit Extension/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/AsakusaSatellite WatchKit Extension/Info.plist
+++ b/AsakusaSatellite WatchKit Extension/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>112</string>
+	<string>114</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/AsakusaSatellite.xcodeproj/project.pbxproj
+++ b/AsakusaSatellite.xcodeproj/project.pbxproj
@@ -868,7 +868,6 @@
 				INFOPLIST_FILE = "AsakusaSatellite WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_NAME = "${TARGET_NAME}";
-				PROVISIONING_PROFILE = "999c7c3e-5f7e-4adb-bf84-1a822cc94889";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "AsakusaSatellite/Common-Bridging-Header.h";
 			};
@@ -884,7 +883,6 @@
 				INFOPLIST_FILE = "AsakusaSatellite WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_NAME = "${TARGET_NAME}";
-				PROVISIONING_PROFILE = "163c49d2-754b-471d-82cf-730bbca5a020";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "AsakusaSatellite/Common-Bridging-Header.h";
 			};
@@ -903,7 +901,6 @@
 				IBSC_MODULE = AsakusaSatellite_WatchKit_Extension;
 				INFOPLIST_FILE = "AsakusaSatellite WatchKit App/Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "9ef0a26a-bf6c-44d1-aab3-95b3e629b9b7";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
 				"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]" = "1,4";
@@ -919,7 +916,6 @@
 				IBSC_MODULE = AsakusaSatellite_WatchKit_Extension;
 				INFOPLIST_FILE = "AsakusaSatellite WatchKit App/Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "d0d667d5-7483-4b85-bbfc-63f19da02c05";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
 				"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]" = "1,4";

--- a/AsakusaSatellite.xcodeproj/xcshareddata/xcschemes/AsakusaSatellite.xcscheme
+++ b/AsakusaSatellite.xcodeproj/xcshareddata/xcschemes/AsakusaSatellite.xcscheme
@@ -110,6 +110,8 @@
             ReferencedContainer = "container:AsakusaSatellite.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -119,6 +121,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/AsakusaSatellite/Info.plist
+++ b/AsakusaSatellite/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>112</string>
+	<string>114</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/AsakusaSatellite/Info.plist
+++ b/AsakusaSatellite/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/AsakusaSatellite/MessageDetailViewController.swift
+++ b/AsakusaSatellite/MessageDetailViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import AsakusaSatellite
 import TUSafariActivity
+import SafariServices
 
 
 class MessageDetailViewController: UIViewController, UIWebViewDelegate {
@@ -92,9 +93,15 @@ class MessageDetailViewController: UIViewController, UIWebViewDelegate {
     // MARK: - WebView
     
     func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
-        if navigationType == .LinkClicked {
-            webview.scalesPageToFit = true
-            navigationController?.setToolbarHidden(false, animated: true)
+        if navigationType == .LinkClicked, let url = request.URL {
+            if #available(iOS 9.0, *) {
+                navigationController?.navigationBar.translucent = true // workaround for SFSafariViewController
+                navigationController?.pushViewController(SFSafariViewController(URL: url), animated: true)
+                return false
+            } else {
+                webview.scalesPageToFit = true
+                navigationController?.setToolbarHidden(false, animated: true)
+            }
         }
         updateToolbar()
         return true

--- a/AsakusaSatellite/RoomViewController.swift
+++ b/AsakusaSatellite/RoomViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import AsakusaSatellite
+import SafariServices
 
 
 private let kCellID = "Cell"
@@ -91,6 +92,8 @@ class RoomViewController: UIViewController, UITableViewDataSource, UITableViewDe
         
         refreshView.refresh()
         tableView.tableFooterView = postView
+        
+        navigationController?.navigationBar.translucent = false // workaround for SFSafariViewController
     }
     
     // MARK: -
@@ -209,7 +212,12 @@ class RoomViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
     
     func onLinkTapped(messageView: MessageView, url: NSURL) {
-        navigationController?.pushViewController(MessageDetailViewController(URL: url), animated: true)
+        if #available(iOS 9.0, *) {
+            navigationController?.navigationBar.translucent = true // workaround for SFSafariViewController
+            navigationController?.pushViewController(SFSafariViewController(URL: url), animated: true)
+        } else {
+            navigationController?.pushViewController(MessageDetailViewController(URL: url), animated: true)
+        }
     }
     
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/AsakusaSatelliteTests/Info.plist
+++ b/AsakusaSatelliteTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>114</string>
 </dict>
 </plist>


### PR DESCRIPTION
to avoid App Transport Security check.
on Xcode 7 b2, pushing to navigation controller whose navigationbar.translucent = false shows duplicated two navigation bars.
