### PR TITLE
Manage App Transport Security

### DIFF
--- a/AsakusaSatellite/Info.plist
+++ b/AsakusaSatellite/Info.plist
@@ -24,6 +24,21 @@
 	<string>111</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>asakusa-satellite.herokuapp.com</key>
+			<dict/>
+			<key>twitter.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
in AsakusaSatellite, many urls in chat messages are http (not https) and we can't whitelist them all.
we need to disable the App Transport Security to display the contents.
even ATS is disabled, we can still opt-in ATS for some domains. API requests and sign-in requests are suitable for the opt-in.
